### PR TITLE
Bumped jackson version to resolve various CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.8.11.20181123</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.11.1</javapoet.version>


### PR DESCRIPTION
Updated Jackson version to 2.9.8

## Description
Updated Jackson version to 2.9.8 to resolve the following CVE:
CVE-2018-14718
CVE-2018-19362
CVE-2018-19360
CVE-2018-14719
CVE-2018-14720
CVE-2018-19361
CVE-2018-14721

## Motivation and Context
Critical security vulnerabilities need to be closed.

## How Has This Been Tested?
No testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
